### PR TITLE
[FIX - EJS] Tweets's users on homepage

### DIFF
--- a/src/views/index.ejs
+++ b/src/views/index.ejs
@@ -19,13 +19,14 @@
                 <p><a href="/mon-compte" class="btn btn-info">Lier un compte twitter</a></p>
             <%}%>
             <% if (tweets.length > 0 && pseudo_twitter !== '') { %>
+                <% console.log(tweets) %>
                         <p class="lead my-3">Voici vos tweets de la semaine : </p>
                         <div class="row my-3">
                             <% tweets.forEach((tweet) => { %>
                                 <div class="card border-secondary mb-3" style="max-width: 20rem;">
                                     <div class="card-body">
                                         <p class="card-text"> 
-                                            <%= tweet.text %>
+                                            <%= tweet.full_text %>
                                         </p>
                                     </div>
                                 </div>


### PR DESCRIPTION
# Description

L'attribut `full_text` n'avait pas été utilisé pour afficher le texte des tweets sur la homepage.

Cocher les mentions utiles

- [ ] Nouvelle fonctionnalité
- [x] Changements critiques
